### PR TITLE
Feature/8 from submodules

### DIFF
--- a/bin/git-rcommit
+++ b/bin/git-rcommit
@@ -102,4 +102,4 @@ EOF
     fi
 fi
 
-cd "$rgit_start_directory"
+restore_wd

--- a/bin/git-rcommit
+++ b/bin/git-rcommit
@@ -60,13 +60,15 @@ do
     esac
 done
 
+source rgit-find-super
+
 ## commit in submodules first
 if [[ $recursive -eq 1 ]]; then
     if [ -f $(git rev-parse --show-toplevel)/.gitmodules ]; then
-        #git submodule --quiet foreach "git rcommit \"$COMMIT_ARGS\"" || exit 1
+        #git submodule --quiet foreach "git rcommit \"$COMMIT_ARGS\"" || restore_wd_exit_1
 	CMD='cd "$1"; git rcommit '"$args"
 	git submodule --quiet foreach 'echo "$toplevel/$path"' | 
-	xargs -r -n1 -P1 bash -c "$CMD" xargs || exit 1
+	xargs -r -n1 -P1 bash -c "$CMD" xargs || restore_wd_exit_1
     fi
 fi
 
@@ -88,7 +90,7 @@ Error in $PWD:
  Refused to commit in detached head state. 
  See "git attach-head --help" for help on attaching the HEAD.
 EOF
-	exit 1
+	restore_wd_exit_1
     fi
 
     echo "Committing in $PWD..."
@@ -100,3 +102,4 @@ EOF
     fi
 fi
 
+cd "$rgit_start_directory"

--- a/bin/git-rpull
+++ b/bin/git-rpull
@@ -5,6 +5,8 @@
 ## if there are such changes, you have to do it by hand
 ## e.g., merge the where there are local and remote changes
 
+set -x
+
 ## read input, display help if necessary
 if [[ "$@" == *--help* ]]; then
     cat<<EOF
@@ -31,8 +33,10 @@ function git
 } 
 export git
 
+source rgit-find-super
+
 ## check for modified content and uncommitted changes
-git check-clean --ignore-submodules=untracked --unstaged --uncommitted --unmerged || exit 1
+git check-clean --ignore-submodules=untracked --unstaged --uncommitted --unmerged || restore_wd_exit_1
 ## check for untracked files
 if ! (git check-clean --untracked --unstaged --exit-code) ; then
     cat >&2 <<EOF
@@ -40,14 +44,14 @@ if ! (git check-clean --untracked --unstaged --exit-code) ; then
   in the respective submodules or remove them.
   Use "git status" to see where they are.
 EOF
-    exit 1
+    restore_wd_exit_1
 fi
 
 ## ensure that we are in the toplevel directory
 cdup=$(git rev-parse --show-toplevel) &&
 cd "$cdup" || {
     echo >&2 "Cannot chdir to $cdup, the toplevel of the working tree"
-    exit 1
+    restore_wd_exit_1
 }
 
 ## check for unpushed commits in submodules
@@ -62,13 +66,13 @@ $unpushed
   push them one-by-one before pulling again. 
   This safety measure ensures that no commits get lost.
 EOF
-	exit 1
+	restore_wd_exit_1
     fi
 fi
 ## git check-unpushed # no need to check in master
 
 ## do the pull
-git pull "$@" || exit 1
+git pull "$@" || restore_wd_exit_1
 
 if [ -f .gitmodules ]; then
     ## fix submodules
@@ -79,3 +83,5 @@ if [ -f .gitmodules ]; then
     ## rfetch does this
     git rfetch
 fi
+
+cd "$rgit_start_directory"

--- a/bin/git-rpull
+++ b/bin/git-rpull
@@ -84,4 +84,4 @@ if [ -f .gitmodules ]; then
     git rfetch
 fi
 
-cd "$rgit_start_directory"
+restore_wd

--- a/bin/git-rpush
+++ b/bin/git-rpush
@@ -27,8 +27,10 @@ function git
 } 
 export git
 
+source rgit-find-super
+
 ## check for modified content and uncommitted changes
-git check-clean --ignore-submodules=untracked --unstaged --uncommitted --unmerged || exit 1
+git check-clean --ignore-submodules=untracked --unstaged --uncommitted --unmerged || restore_wd_exit_1
 ## check for untracked files
 if ! (git check-clean --untracked --unstaged --exit-code) ; then
     cat >&2 <<EOF
@@ -41,9 +43,9 @@ fi
 ## check for non remote tracking branches and fail
 ## TODO: if not --all
 if [ -f $(git rev-parse --show-toplevel)/.gitmodules ]; then
-    #git submodule --quiet foreach --recursive "git check-branch" || exit 1
+    #git submodule --quiet foreach --recursive "git check-branch" || restore_wd_exit_1
     git submodule --quiet foreach --recursive 'echo "$toplevel/$path"' | 
-    xargs -r -n1 -P5 bash -c 'cd "$1"; git check-branch' xargs || exit 1
+    xargs -r -n1 -P5 bash -c 'cd "$1"; git check-branch' xargs || restore_wd_exit_1
 fi
 ## TODO: check for unpulled changes: fetch, then check
 # git fetch -q
@@ -51,3 +53,5 @@ fi
 
 ## push super rep.
 git cpush -q "$@"
+
+cd "$rgit_start_directory"

--- a/bin/git-rpush
+++ b/bin/git-rpush
@@ -54,4 +54,4 @@ fi
 ## push super rep.
 git cpush -q "$@"
 
-cd "$rgit_start_directory"
+restore_wd

--- a/bin/rgit-find-super
+++ b/bin/rgit-find-super
@@ -38,8 +38,11 @@ fi
 # get the present directory and define restore_wd_exit_1
 export rgit_start_directory=$(pwd)
 
-function restore_wd_exit_1 () {
+function restore_wd () {
     cd "$rgit_start_directory"
+}
+function restore_wd_exit_1 () {
+    restore_wd
     exit 1
 }
 

--- a/bin/rgit-find-super
+++ b/bin/rgit-find-super
@@ -1,0 +1,64 @@
+#! /bin/bash -e
+
+# Cases not covered:
+#  1. 'gitdir' is in a .git file in the git toplevel, although not a submodule
+#     Note: git worktree produces such files
+#  2. a git repo sitting inside another git repo, but not a submodule
+#  3. a submodule that does not use a .git file containing 'gitdir'
+#     Note: git v1.7.9.5 (and later) produces the needed files
+
+#set -x
+
+# attempt to ensure this is sourced and not run as a script (not a guarantee)
+if [[ $BASH_SOURCE == $0 ]] ; then
+    cat >&2 <<EOF
+ Error: Cannot call $(basename $BASH_SOURCE) as a script!"
+  Instead, source $0 to run it.  That is:
+    #$ source $(basename $0)  # if on the path
+  or
+    #$ . $(basename $0)       # if on the path
+  or (if not on the path)
+    #$ source $0
+    #$ . $0
+EOF
+    exit 1
+fi
+
+# Protect against multiple calls to this function
+if [ ! -z ${rgit_start_directory+x} ] ; then
+    cat >&2 <<EOF
+ Error: Attempt to call $(basename $BASH_SOURCE) multiple times"
+  present implementation does not support this
+EOF
+    return 1 || exit 1
+fi
+# now=$(date +%s)
+# if [ ! -z ${rgit_find_super_start+x} ] ; then
+#     export prev_rgit_find_super_start=$rgit_find_super_start
+# fi
+# export rgit_find_super_start=$now
+
+# ...
+export rgit_start_directory=$(pwd)
+immediate_git_root=$(git rev-parse --show-toplevel)
+parent_of_present_git_root="$(dirname "$immediate_git_root")"
+
+if ! (cd "$parent_of_present_git_root" \
+        && git rev-parse --show-toplevel 2>&1 > /dev/null) ;
+then
+    # Do nothing - parent is not a git repo
+    return 0 || exit 1
+fi
+
+# Change to toplevel parent git repo dir and return
+cd $(cd "$parent_of_present_git_root" \
+       && git rev-parse --show-toplevel 2>/dev/null)
+return 0 || exit 1
+
+# this_dot_git="$immediate_git_root/.git"
+# parent_of_start_directory=$(dirname $rgit_start_directory)
+# [ -e "$this_dot_git" ] \
+#   && [ ! -d "$this_dot_git" ] \
+#   && grep gitdir "$this_dot_git" >/dev/null ] \
+#   && [ ! -d "$(git rev-parse --show-toplevel)/.git" ]
+#       pwd && return 0 || exit 1

--- a/bin/rgit-find-super
+++ b/bin/rgit-find-super
@@ -7,7 +7,9 @@
 #  3. a submodule that does not use a .git file containing 'gitdir'
 #     Note: git v1.7.9.5 (and later) produces the needed files
 
-#set -x
+# TODO
+#  a. Produces a lot of warnings
+#  b. mitigate issue where variable rgit_start_directory can break functionality
 
 # attempt to ensure this is sourced and not run as a script (not a guarantee)
 if [[ $BASH_SOURCE == $0 ]] ; then
@@ -27,19 +29,20 @@ fi
 # Protect against multiple calls to this function
 if [ ! -z ${rgit_start_directory+x} ] ; then
     cat >&2 <<EOF
- Error: Attempt to call $(basename $BASH_SOURCE) multiple times"
-  present implementation does not support this
+ Warning: called $(basename $BASH_SOURCE) multiple times"
+  present implementation assumes no action required
 EOF
-    return 1 || exit 1
+    return 0 || exit 0
 fi
-# now=$(date +%s)
-# if [ ! -z ${rgit_find_super_start+x} ] ; then
-#     export prev_rgit_find_super_start=$rgit_find_super_start
-# fi
-# export rgit_find_super_start=$now
 
-# ...
+# get the present directory and define restore_wd_exit_1
 export rgit_start_directory=$(pwd)
+
+function restore_wd_exit_1 () {
+    cd "$rgit_start_directory"
+    exit 1
+}
+
 immediate_git_root=$(git rev-parse --show-toplevel)
 parent_of_present_git_root="$(dirname "$immediate_git_root")"
 
@@ -54,11 +57,3 @@ fi
 cd $(cd "$parent_of_present_git_root" \
        && git rev-parse --show-toplevel 2>/dev/null)
 return 0 || exit 1
-
-# this_dot_git="$immediate_git_root/.git"
-# parent_of_start_directory=$(dirname $rgit_start_directory)
-# [ -e "$this_dot_git" ] \
-#   && [ ! -d "$this_dot_git" ] \
-#   && grep gitdir "$this_dot_git" >/dev/null ] \
-#   && [ ! -d "$(git rev-parse --show-toplevel)/.git" ]
-#       pwd && return 0 || exit 1


### PR DESCRIPTION
This merge request provides initial/basic - but fragile - functionality to address https://github.com/quakefinder/git-submodule-tools/issues/8

Of particular interest for review is the use of a variable (rgit_start_directory) in the bash helper, rgit-find-super, that is defined early in execution of a command and presently suppresses subsequent executions of the helper.  This seem like it could be fragile.  Pending review, subsequent executions produce a warning.

Two likely options include:

1. disable the warnings and accept the fragility
2. attempt to only execute the helper once (for instance by passing command line arguments back to scripts when executed as helpers within the scripts as opposed to when called by users OR by detecting that we are at the top of a super-repo before calling the helper)